### PR TITLE
[FCO-120][UPD][debo_fuel_tanks,fuel_tanks_cash_control]

### DIFF
--- a/debo_fuel_tanks/views/cash_control_session.xml
+++ b/debo_fuel_tanks/views/cash_control_session.xml
@@ -13,7 +13,7 @@
                 <button name="action_test_button" type="object" string="TEST"/>
             </xpath>
             <xpath expr="//notebook" position="inside">
-            <page string="Other Dispatchs" name="other_dispatch">
+            <page string="Other Dispatchs" name="other_dispatch" attrs="{'invisible':[('config_sells_fuel','=',False)]}">
                     <field name="other_dispatch_line_ids">
                         <tree>
                             <field name="order_id" string="Move Number"/>
@@ -23,7 +23,7 @@
                         </tree>
                     </field>
                 </page>
-                <page string="Pump Tests" name="pump_tests">
+                <page string="Pump Tests" name="pump_tests" attrs="{'invisible':[('config_sells_fuel','=',False)]}">
                     <field name="pump_test_line_ids">
                         <tree>
                             <field name="order_id" string="Move Number"/>

--- a/fuel_tanks_cash_control/__manifest__.py
+++ b/fuel_tanks_cash_control/__manifest__.py
@@ -26,6 +26,7 @@
     ],
     "data": [
         "security/ir.model.access.csv",
+        "views/cash_control_config.xml",
         "views/cash_control_session.xml",
         "views/stock_picking.xml",
     ],

--- a/fuel_tanks_cash_control/i18n/es_AR.po
+++ b/fuel_tanks_cash_control/i18n/es_AR.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-04-13 13:56+0000\n"
-"PO-Revision-Date: 2022-04-13 13:56+0000\n"
+"POT-Creation-Date: 2022-05-30 12:38+0000\n"
+"PO-Revision-Date: 2022-05-30 12:38+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -21,9 +21,25 @@ msgid "Amount"
 msgstr "Importe"
 
 #. module: fuel_tanks_cash_control
+#: model:ir.model,name:fuel_tanks_cash_control.model_cash_control_config
+msgid "Cash Control Config"
+msgstr "Control de Turnos"
+
+#. module: fuel_tanks_cash_control
 #: model:ir.model,name:fuel_tanks_cash_control.model_cash_control_session
+#: model:ir.model.fields,field_description:fuel_tanks_cash_control.field_stock_picking__cash_control_session_id
 msgid "Cash Control Session"
 msgstr "Sesión"
+
+#. module: fuel_tanks_cash_control
+#: model:ir.model.fields,field_description:fuel_tanks_cash_control.field_cash_control_session__config_is_shop
+msgid "Cashbox is Shop"
+msgstr "Es una caja de Tienda"
+
+#. module: fuel_tanks_cash_control
+#: model:ir.model.fields,field_description:fuel_tanks_cash_control.field_cash_control_session__config_sells_fuel
+msgid "Cashbox sells Fuel"
+msgstr "Vende Combustible"
 
 #. module: fuel_tanks_cash_control
 #: model:ir.model.fields,field_description:fuel_tanks_cash_control.field_fuel_move_line__pump_code
@@ -66,19 +82,29 @@ msgid "Fuel Movements"
 msgstr "Movimientos de Combustible"
 
 #. module: fuel_tanks_cash_control
+#: model:ir.model.fields,field_description:fuel_tanks_cash_control.field_cash_control_session__fuel_stock_picking_ids
+msgid "Fuel Stock Pickings"
+msgstr "Movimiento de Stock de combustible"
+
+#. module: fuel_tanks_cash_control
 #: model:ir.model.fields,field_description:fuel_tanks_cash_control.field_fuel_move_line__id
 msgid "ID"
 msgstr ""
 
 #. module: fuel_tanks_cash_control
-#: model:ir.model.fields,field_description:fuel_tanks_cash_control.field_fuel_move_line__pump_id_debo
-msgid "ID DEBO"
-msgstr "ID DEBO"
-
-#. module: fuel_tanks_cash_control
 #: model:ir.model.fields,field_description:fuel_tanks_cash_control.field_fuel_move_line__initial_qty
 msgid "Initial Quantity"
 msgstr "Inicial"
+
+#. module: fuel_tanks_cash_control
+#: model:ir.model.fields,field_description:fuel_tanks_cash_control.field_cash_control_config__is_fuel_cashbox
+msgid "Is Fuel Cashbox"
+msgstr "Es una caja de Playa"
+
+#. module: fuel_tanks_cash_control
+#: model:ir.model.fields,field_description:fuel_tanks_cash_control.field_cash_control_config__is_shop_cashbox
+msgid "Is Shop Cashbox"
+msgstr "Es una caja de Tienda"
 
 #. module: fuel_tanks_cash_control
 #: model:ir.model.fields,field_description:fuel_tanks_cash_control.field_fuel_move_line____last_update
@@ -99,12 +125,6 @@ msgstr ""
 #: model:ir.model.fields,field_description:fuel_tanks_cash_control.field_fuel_move_line__manual_qty
 msgid "Manual Quantity"
 msgstr "Manual"
-
-#. module: fuel_tanks_cash_control
-#: model:ir.model.fields,field_description:fuel_tanks_cash_control.field_cash_control_session__id_debo
-#: model:ir.model.fields,field_description:fuel_tanks_cash_control.field_fuel_move_line__id_debo
-msgid "Planilla"
-msgstr "Planilla"
 
 #. module: fuel_tanks_cash_control
 #: model:ir.model.fields,field_description:fuel_tanks_cash_control.field_fuel_move_line__price
@@ -133,10 +153,27 @@ msgstr "Surtidores"
 
 #. module: fuel_tanks_cash_control
 #: model:ir.model.fields,field_description:fuel_tanks_cash_control.field_fuel_move_line__session_id
+#: model:ir.model.fields,field_description:fuel_tanks_cash_control.field_stock_move__cash_control_session_id
 msgid "Session"
 msgstr "Sesión"
+
+#. module: fuel_tanks_cash_control
+#: model:ir.model,name:fuel_tanks_cash_control.model_stock_move
+msgid "Stock Move"
+msgstr "Movimiento de existencias"
 
 #. module: fuel_tanks_cash_control
 #: model:ir.model.fields,field_description:fuel_tanks_cash_control.field_fuel_move_line__tank_id
 msgid "Tank"
 msgstr "Tanque"
+
+#. module: fuel_tanks_cash_control
+#: code:addons/fuel_tanks_cash_control/models/cash_control_session.py:0
+#, python-format
+msgid "That cashbox cannot have pumps associated"
+msgstr "Esa caja no puede tener Surtidores asociados"
+
+#. module: fuel_tanks_cash_control
+#: model:ir.model,name:fuel_tanks_cash_control.model_stock_picking
+msgid "Transfer"
+msgstr "Albarán"

--- a/fuel_tanks_cash_control/models/__init__.py
+++ b/fuel_tanks_cash_control/models/__init__.py
@@ -1,4 +1,5 @@
-from . import fuel_move_line
+from . import cash_control_config
 from . import cash_control_session
+from . import fuel_move_line
 from . import stock_move
 from . import stock_picking

--- a/fuel_tanks_cash_control/models/cash_control_config.py
+++ b/fuel_tanks_cash_control/models/cash_control_config.py
@@ -1,0 +1,8 @@
+from odoo import models, fields
+
+class CashControlConfig(models.Model):
+    _inherit = "cash.control.config"
+
+    is_fuel_cashbox = fields.Boolean()
+    is_shop_cashbox = fields.Boolean()
+

--- a/fuel_tanks_cash_control/views/cash_control_config.xml
+++ b/fuel_tanks_cash_control/views/cash_control_config.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="cash_control_config_add_fuel_form" model="ir.ui.view">
+        <field name="name">cash.control.config.form.inherit</field>
+        <field name="model">cash.control.config</field>
+        <field name="inherit_id" ref="cash_control.cash_control_config_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='code']" position="after">
+                <field name="is_fuel_cashbox"/>
+                <field name="is_shop_cashbox"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/fuel_tanks_cash_control/views/cash_control_session.xml
+++ b/fuel_tanks_cash_control/views/cash_control_session.xml
@@ -6,16 +6,17 @@
         <field name="inherit_id" ref="cash_control.cash_control_session_form" />
         <field name="arch" type="xml">
             <xpath expr="//field[@name='payment_journal_ids']" position="after">
-                <field name="pump_ids" widget="many2many_tags" attrs="{'readonly': [('state', '!=', 'draft')],'invisible':['&amp;',('state','!=','draft'),('pump_ids','=',[])]}" />
+                <field name="config_sells_fuel" invisible="1"/>
+                <field name="pump_ids" widget="many2many_tags" attrs="{'readonly': [('state', '!=', 'draft')],'invisible':['&amp;',('state','!=','draft'),('config_sells_fuel','=',False)]}" />
             </xpath>
             <xpath expr="//notebook">
-                <page name="pumps" string="Pump details" attrs="{'invisible':[('pump_ids','=',[])]}">
+                <page name="pumps" string="Pump details" attrs="{'invisible':[('config_sells_fuel','=',False)]}">
                     <field name="fuel_move_ids" attrs="{'readonly': [('state', '!=', 'draft')]}">
                         <!-- TODO: find a way to show fields grouped by tank_id -->
                         <tree editable="bottom">
                             <field name="tank_id" invisible="1" />
                             <field name="price" />
-                            <field name="product_id" />                
+                            <field name="product_id" />
                             <field name="pump_code" colspan="1" />
                             <field name="initial_qty" />
                             <field name="final_qty" />


### PR DESCRIPTION
- add fields to cc.config to distinguish between a shop and fuel type config (some might be both)
- changed how fields/pages are displayed according to said value
- add constraint for trying to open a non fuel type session with pumps
- views and translations