### PR TITLE
[FCO-181][UPD][api_sale,fuel_tanks_cash_control]

### DIFF
--- a/fuel_tanks_cash_control/models/cash_control_config.py
+++ b/fuel_tanks_cash_control/models/cash_control_config.py
@@ -1,8 +1,16 @@
 from odoo import models, fields
 
+
 class CashControlConfig(models.Model):
     _inherit = "cash.control.config"
 
     is_fuel_cashbox = fields.Boolean()
     is_shop_cashbox = fields.Boolean()
 
+    # TODO: add base field in cash_control_extension
+    location_id = fields.Many2one(
+        comodel_name="stock.location",
+        string="Location",
+        domain=[("usage", "=", "internal"), ("is_fuel_tank", "=", False)],
+        help="Default location to deduce stock for non fuel products"
+    )

--- a/fuel_tanks_cash_control/models/cash_control_config.py
+++ b/fuel_tanks_cash_control/models/cash_control_config.py
@@ -7,7 +7,6 @@ class CashControlConfig(models.Model):
     is_fuel_cashbox = fields.Boolean()
     is_shop_cashbox = fields.Boolean()
 
-    # TODO: add base field in cash_control_extension
     location_id = fields.Many2one(
         comodel_name="stock.location",
         string="Location",


### PR DESCRIPTION
- change domain of location_id to exclude tanks
- non fuel sales created through api should always have as warehouse_id the intended one